### PR TITLE
Fix checkver path, update to 1.58.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           repository: ScoopInstaller/Scoop
           path: scoop_core
       - name: Init Test Suite
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           modules-to-cache: BuildHelpers
           shell: powershell
@@ -48,7 +48,7 @@ jobs:
           repository: ScoopInstaller/Scoop
           path: scoop_core
       - name: Init Test Suite
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           modules-to-cache: BuildHelpers
           shell: pwsh

--- a/bucket/smithy-cli.json
+++ b/bucket/smithy-cli.json
@@ -1,16 +1,15 @@
 {
-    "version": "1.50.0",
+    "version": "1.58.0",
     "description": "Smithy CLI - A CLI for building, validating, querying, and iterating on Smithy models",
     "homepage": "https://smithy.io",
     "license": "Apache-2.0",
-    "url": "https://github.com/smithy-lang/smithy/releases/download/1.50.0/smithy-cli-windows-x64.zip",
-    "hash": "ceed7321960ffb3e246fc3b2a0ab3b82a1290d41d5ccacf53e209a61ee444e59",
+    "url": "https://github.com/smithy-lang/smithy/releases/download/1.58.0/smithy-cli-windows-x64.zip",
+    "hash": "ca7c02ebf6887a1fca738a01fc54cdfa7a610ca466a212b1c32168f27dfd8a20",
     "extract_dir": "smithy-cli-windows-x64",
     "env_add_path": "bin",
     "post_install": "smithy warmup",
     "checkver": {
-        "url": "https://github.com/smithy-lang/smithy/releases/latest/download/VERSION",
-        "re": "([\\d.]+)"
+        "github": "https://github.com/smithy-lang/smithy"
     },
     "autoupdate": {
         "url": "https://github.com/smithy-lang/smithy/releases/download/$version/smithy-cli-windows-x64.zip",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

* Fix checkver path to use simpler the built-in GitHub version lookup logic ([docs](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate#special-cases))
* Update to 1.58.0

```
Running tests from 'Scoop-Bucket.Tests.ps1'
Describing Code Syntax
  [+] PowerShell code files do not contain syntax errors 64ms (5ms|59ms)

Describing Style constraints for non-binary project files
  [+] files do not contain leading UTF-8 BOM 32ms (30ms|2ms)
  [+] files end with a newline 3ms (3ms|1ms)
  [+] file newlines are CRLF 5ms (5ms|1ms)
  [+] files have no lines containing trailing whitespace 7ms (7ms|1ms)
  [+] any leading whitespace consists only of spaces (excepting makefiles) 9ms (8ms|1ms)

Describing Manifest validates against the schema
  [+] C:\Users\simon\Documents\Workspace\scoop-bucket\bucket\smithy-cli.json 493ms (489ms|4ms)
Tests completed in 831ms
Tests Passed: 7, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0
```

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
