### PR TITLE
Grant write permissions to excavator job

### DIFF
--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -2,12 +2,14 @@ on:
   workflow_dispatch:
   schedule:
     # run every 12 hours
-    - cron: '20 */12 * * *'
+    - cron: "20 */12 * * *"
 name: Excavator
 jobs:
   excavate:
     name: Excavate
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@main
       - name: Excavate


### PR DESCRIPTION
Grant write permissions to excavator job. The job is currently failing with: 

```
remote: Permission to smithy-lang/scoop-bucket.git denied to github-actions[bot].
```


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
